### PR TITLE
Switch to using python for determining the path 

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,28 +4,14 @@
 # Python
 #
 
-WITH_PYPY=${WITH_PYPY:=0}
-
-# On OSX, we must use greadlink (aka gnu readlink) for -m.
-# This is installed via homebrew coreutils.
-READLINK=$(which greadlink || which readlink)
-
 rm -rf build/
-PYTHON_ENV=$($READLINK -m ./_python-env)
 
-# Fetch virtualenv
-if [[ $WITH_PYPY -eq 1 ]]; then
-  PYTHON=$(which pypy)
-  if ! which pypy; then
-    echo "PyPy was not found.  You can download from:"
-    echo "http://pypy.org/download.html"
-    echo 'https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-linux64.tar.bz2  (linux)'
-    echo 'https://bitbucket.org/pypy/pypy/downloads/pypy3-2.1-beta1-osx64.tar.bz2 (mac)'
-    exit
-  fi
-else
-  PYTHON=$(which python)
-fi
+# We emulate readlink with python, so we can work on OSX without greadlink.
+# From: http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-
+# of-gnus-readlink-f-on-a-mac
+PYTHON_ENV=$(python -c 'import os,sys;print os.path.realpath(sys.argv[1])' ./_python-env)
+
+PYTHON=$(which python)
 
 pip install --user virtualenv
 


### PR DESCRIPTION
So we can eliminate the greadlink dependency on OSX. Fixes #8
