### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "2.7"
+install:
+  - python setup.py develop
+  - pushd api/faers && npm install && popd
+script:
+  - python setup.py test
+  - pushd api/faers && npm test && popd

--- a/setup.py
+++ b/setup.py
@@ -31,4 +31,5 @@ setuptools.setup(
               'openfda.spl',
               ],
   zip_safe=False,
+  test_suite = 'nose.collector',
 )


### PR DESCRIPTION
Since travis doesn't natively support multiple languages (see:
http://stackoverflow.com/questions/18456611/is-it-possible-to-set-up-tra
vis-to-run-tests-for-several-languages), we ask for python 2.7 and we
use whatever version of node is installed on the base image.
