### PR TITLE
Refactoring MAUDE pipeline to use a load and swap design on Elasticsearch

### DIFF
--- a/openfda/parallel.py
+++ b/openfda/parallel.py
@@ -138,11 +138,11 @@ class XMLDictInput(MapInput):
   def __iter__(self):
     _item = []
     def _handler(_, ord_dict):
-      _item.append(json.dumps(ord_dict))
+      _item.append(json.loads(json.dumps(ord_dict)))
       return True
 
     xml_file = open(self.filename).read()
-    xmltodict.parse(xml_file, item_depth=2, item_callback=_handler)
+    xmltodict.parse(xml_file, item_depth=1, item_callback=_handler)
 
     for idx, line in enumerate(_item):
       yield str(idx), line


### PR DESCRIPTION
This approach allows MAUDE to be loaded against a live cluster even though it is not technically versioned. We simply load into a new index and then point the deviceevent alias from the old index to the new index

R: @mattmo 