### PR TITLE
Download file ranges

### DIFF
--- a/openfda/export/pipeline.py
+++ b/openfda/export/pipeline.py
@@ -63,15 +63,21 @@ FILTERED_ENPOINT_MAP = {
 # structure tells us the data range, the key to query as well as the chunk size
 # to use for a larger payload.
 RANGE_ENDPOINT_MAP = {
+  # The end_date should be set to the date of the latest data availability
+  # If you do not set this correctly, too much data collects in the `All other data` zip files
+  # Check here for drug event:
+  # https://www.fda.gov/drugs/guidancecomplianceregulatoryinformation/surveillance/adversedrugeffects/ucm082193.htm
   '/drug/event': {
     'date_key': '@timestamp',
     'start_date': '2004-01-01',
-    'end_date': '2016-01-01'
+    'end_date': '2017-04-01'
   },
+  # Check here for device event:
+  # https://www.fda.gov/MedicalDevices/DeviceRegulationandGuidance/PostmarketRequirements/ReportingAdverseEvents/ucm127891.htm
   '/device/event': {
     'date_key': 'date_received',
     'start_date': '1991-10-01',
-    'end_date': '2016-08-01'
+    'end_date': '2017-07-01'
   },
 }
 


### PR DESCRIPTION
Increase the end_date value for both device and drug adverse events so that the zip files are bucketed correctly. Too much data is being stuck into the `All other data` files since this value has not been increase.

These dates need to be increased every so often so that the downloads are not lopsided. Let me know if you have any questions.