### PR TITLE
Latest changes in openFDA that include a Docker Compose configuration to run the pipelines and API locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:2
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN apt-get install -y nodejs netcat
+WORKDIR /usr/src/openfda
+ADD . ./
+RUN rm -rf .eggs _python-env openfda.egg-info logs
+RUN ./bootstrap.sh
+CMD ["./scripts/all-pipelines-docker.sh"]

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ openFDA is a research project to provide open APIs, raw data downloads, document
 
 This repository contains the code which powers all of the `api.fda.gov` end points:
 
-* Python pipelines written with [Luigi](https://github.com/spotify/luigi) for processing public FDA data sets (drugs, foods, and medical devices) into a JSON format that can be loaded into Elasticsearch.
+* Python pipelines written with [Luigi](https://github.com/spotify/luigi) for processing public FDA data sets (drugs, foods, medical devices, and other) into a JSON format that can be loaded into Elasticsearch.
 
 * [Elasticsearch](http://www.elasticsearch.org/) schemas for the available data sets.
 
-* A [Node.js](https://github.com/joyent/node) API Server written with [Express](http://expressjs.com/), [Elasticsearch.js](http://www.elasticsearch.org/guide/en/elasticsearch/client/javascript-api/current/) and [Elastic.js](http://www.fullscale.co/elasticjs/) that communicates with Elasticsearch and provides the `api.fda.gov` JSON interface (documented in detail at http://open.fda.gov).
+* A [Node.js](https://github.com/joyent/node) API Server written with [Express](http://expressjs.com/), [Elasticsearch.js](http://www.elasticsearch.org/guide/en/elasticsearch/client/javascript-api/current/) and [Elastic.js](http://www.fullscale.co/elasticjs/) that communicates with Elasticsearch and provides the `api.fda.gov` JSON interface (documented in detail at https://open.fda.gov).
 
 # Prerequisites
 
@@ -26,3 +26,24 @@ This repository contains the code which powers all of the `api.fda.gov` end poin
 # Packaging
 
 Run `bootstrap.sh` to download and setup a virtualenv for the `openfda` python package and to download and setup the `openfda-api` node package.
+
+# Running in Docker
+
+If you intend to try and run openFDA yourself, we have put together a `docker-compose.yml` configuration
+ that can help you get started. `docker-compose up` will:
+1. Start an [Elasticsearch](http://www.elasticsearch.org/) container
+2. Start an API container, which will expose port `8000` for queries.
+3. Start a Python 2.7 container that will run the NSDE, CAERS, and Substance Data pipelines and
+create corresponding indices in Elasticsearch.
+
+Note: even though the API container starts right away, it will not serve any data until some or all
+of the pipelines above have finished running. You can `curl http://localhost:8000/status` to see which
+endpoints have become available as the pipelines progress or after they have completed running. Once an
+endpoint becomes available, it can be queried using the standard openFDA
+[query syntax](https://open.fda.gov/apis/query-syntax/).
+For example: `curl -g 'http://localhost:8000/food/event.json?search=products.industry_name:"Soft+Drink/Water"+AND+reactions.exact:DEHYDRATION&limit=10'`
+
+At this point the Python container only runs the NSDE, CAERS, and Substance Data pipelines because those
+are relatively lightweight and require no access to internal FDA networks. We will add more pipelines
+in case there is substantial interest from the community. However, the three pipelines above provide a good starting
+point into understanding openFDA internals and/or customizing openFDA.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+
+services:
+  es:
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.16
+    environment:
+      - xpack.security.enabled=false
+    ports:
+      - "9200"
+  api:
+    build: ./api/faers
+    environment:
+      - ES_HOST=es:9200
+    depends_on:
+      - es
+    ports:
+      - 8000:8000
+  pipeline:
+    build: .
+    environment:
+      - ES_HOST=es:9200
+    depends_on:
+      - es

--- a/openfda/config.py
+++ b/openfda/config.py
@@ -44,7 +44,7 @@ def es_client(host=None):
   if host is None:
     host = es_host()
 
-  return elasticsearch.Elasticsearch(host, timeout=120)
+  return elasticsearch.Elasticsearch(host, timeout=180)
 
 def data_dir(*subdirs):
   return os.path.join(FDAConfig().data_dir, *subdirs)

--- a/scripts/all-pipelines-docker.sh
+++ b/scripts/all-pipelines-docker.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -x
+
+export LUIGI_CONFIG_PATH=./config/luigi.cfg
+export PYTHON=./_python-env/bin/python
+export LOGDIR=./logs
+
+mkdir -p $LOGDIR
+
+es_host="${ES_HOST:-localhost:9200}"
+BASEDIR=$(dirname "$0")
+$BASEDIR/wait-for.sh $es_host -t 120
+
+$PYTHON openfda/nsde/pipeline.py LoadJSON --FDAConfig-es-host=$es_host
+$PYTHON openfda/caers/pipeline.py LoadJSON --FDAConfig-es-host=$es_host
+$PYTHON openfda/substance_data/pipeline.py LoadJSON --FDAConfig-es-host=$es_host
+
+#$PYTHON openfda/classification/pipeline.py LoadJSON --FDAConfig-es-host=$es_host
+#$PYTHON openfda/device_pma/pipeline.py LoadJSON --FDAConfig-es-host=$es_host
+#$PYTHON openfda/device_clearance/pipeline.py LoadJSON --FDAConfig-es-host=$es_host
+#$PYTHON openfda/registration/pipeline.py LoadJSON --FDAConfig-es-host=$es_host
+#$PYTHON openfda/annotation_table/pipeline.py CombineHarmonization --FDAConfig-es-host=$es_host > $LOGDIR/annotation.log 2>&1
+#$PYTHON openfda/ndc/pipeline.py LoadJSON --FDAConfig-es-host=$es_host > $LOGDIR/ndc.log 2>&1
+#$PYTHON openfda/faers/pipeline.py LoadJSON --FDAConfig-es-host=$es_host --quarter=all > $LOGDIR/faers.log 2>&1
+#$PYTHON openfda/res/pipeline.py RunWeeklyProcess --FDAConfig-es-host=$es_host > $LOGDIR/res.log 2>&1
+#$PYTHON openfda/spl/pipeline.py ProcessBatch --FDAConfig-es-host=$es_host > $LOGDIR/spl.log 2>&1
+#$PYTHON openfda/adae/pipeline.py LoadJSON --FDAConfig-es-host=$es_host > $LOGDIR/adae.log 2>&1
+#$PYTHON openfda/device_recall/pipeline.py LoadJSON --FDAConfig-es-host=$es_host > $LOGDIR/device_recall.log 2>&1
+#$PYTHON openfda/maude/pipeline.py LoadJSON --FDAConfig-es-host=$es_host > $LOGDIR/maude.log 2>&1
+#$PYTHON openfda/device_udi/pipeline.py LoadJSON --FDAConfig-es-host=$es_host > $LOGDIR/device_udi.log 2>&1
+#$PYTHON openfda/covid19serology/pipeline.py LoadJSON --FDAConfig-es-host=$es_host > $LOGDIR/serology.log 2>&1

--- a/scripts/wait-for.sh
+++ b/scripts/wait-for.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+TIMEOUT=15
+QUIET=0
+
+echoerr() {
+  if [ "$QUIET" -ne 1 ]; then printf "%s\n" "$*" 1>&2; fi
+}
+
+usage() {
+  exitcode="$1"
+  cat << USAGE >&2
+Usage:
+  $cmdname host:port [-t timeout] [-- command args]
+  -q | --quiet                        Do not output any status messages
+  -t TIMEOUT | --timeout=timeout      Timeout in seconds, zero for no timeout
+  -- COMMAND ARGS                     Execute command with args after the test finishes
+USAGE
+  exit "$exitcode"
+}
+
+wait_for() {
+  for i in `seq $TIMEOUT` ; do
+    nc -z "$HOST" "$PORT" > /dev/null 2>&1
+
+    result=$?
+    if [ $result -eq 0 ] ; then
+      if [ $# -gt 0 ] ; then
+        exec "$@"
+      fi
+      exit 0
+    fi
+    sleep 1
+  done
+  echo "Operation timed out" >&2
+  exit 1
+}
+
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    *:* )
+    HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
+    PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
+    shift 1
+    ;;
+    -q | --quiet)
+    QUIET=1
+    shift 1
+    ;;
+    -t)
+    TIMEOUT="$2"
+    if [ "$TIMEOUT" = "" ]; then break; fi
+    shift 2
+    ;;
+    --timeout=*)
+    TIMEOUT="${1#*=}"
+    shift 1
+    ;;
+    --)
+    shift
+    break
+    ;;
+    --help)
+    usage 0
+    ;;
+    *)
+    echoerr "Unknown argument: $1"
+    usage 1
+    ;;
+  esac
+done
+
+if [ "$HOST" = "" -o "$PORT" = "" ]; then
+  echoerr "Error: you need to provide a host and port to test."
+  usage 2
+fi
+
+wait_for "$@"


### PR DESCRIPTION
# Running in Docker

If you intend to try and run openFDA yourself, we have put together a `docker-compose.yml` configuration
 that can help you get started. `docker-compose up` will:
1. Start an [Elasticsearch](http://www.elasticsearch.org/) container
2. Start an API container, which will expose port `8000` for queries.
3. Start a Python 2.7 container that will run the NSDE, CAERS, and Substance Data pipelines and
create corresponding indices in Elasticsearch.

Note: even though the API container starts right away, it will not serve any data until some or all
of the pipelines above have finished running. You can `curl http://localhost:8000/status` to see which
endpoints have become available as the pipelines progress or after they have completed running. Once an
endpoint becomes available, it can be queried using the standard openFDA
[query syntax](https://open.fda.gov/apis/query-syntax/).
For example: `curl -g 'http://localhost:8000/food/event.json?search=products.industry_name:"Soft+Drink/Water"+AND+reactions.exact:DEHYDRATION&limit=10'`

At this point the Python container only runs the NSDE, CAERS, and Substance Data pipelines because those
are relatively lightweight and require no access to internal FDA networks. We will add more pipelines
in case there is substantial interest from the community. However, the three pipelines above provide a good starting
point into understanding openFDA internals and/or customizing openFDA.
