### PR TITLE
Added ulimits to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,3 +21,8 @@ services:
       - ES_HOST=es:9200
     depends_on:
       - es
+    ulimits:
+      nproc: 65535
+      nofile:
+        soft: 65535
+        hard: 65535


### PR DESCRIPTION
Added ulimits to the pipeline container to overcome 'Too many open files' error from LevelDB in MAUDE:

```
leveldb.LevelDBError: IO error: ./data/maude/init-2020-12-20-json.db-mapreduce-output-2020-12-22-05-27/shard-00001-of-00002.db: Too many open files
```
Fixes #150 

