### PR TITLE
Add missing openfda fields to classification schema

### DIFF
--- a/schemas/deviceclass_schema.json
+++ b/schemas/deviceclass_schema.json
@@ -33,6 +33,18 @@
           },
           "type": "array"
         },
+        "k_number": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "pma_number": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "registration_number": {
           "items": {
             "type": "string"


### PR DESCRIPTION
Fixes #199

The classification JSON schema was missing openfda.k_number and openfda.pma_number even though those fields are returned by the API and already present in classification_mapping.json.

This adds both fields under openfda as arrays of strings in schemas/deviceclass_schema.json.

Verified by checking live API responses:
- search=openfda.k_number:* returns openfda.k_number
- search=openfda.pma_number:* returns openfda.pma_number

and confirming those keys are now present in the schema.